### PR TITLE
fix: remove meaningless semi-colon in ghidra/decompile.py

### DIFF
--- a/ghidra/decompile.py
+++ b/ghidra/decompile.py
@@ -23,7 +23,7 @@ args = ghidra_app.getScriptArgs()
 decompinterface = DecompInterface()
 
 # Open Current Program
-decompinterface.openProgram(currentProgram);
+decompinterface.openProgram(currentProgram)
 
 # Get Binary Functions
 functions = currentProgram.getFunctionManager().getFunctions(True)


### PR DESCRIPTION
### Problem

- In line 26 at `ghidra/decompile.py`, there is meaningless semi-colon.

### Fix

- Removed semi-colon.